### PR TITLE
Add support for 64mb disks

### DIFF
--- a/COMMELL-LE564
+++ b/COMMELL-LE564
@@ -128,6 +128,7 @@ option		RAMDISK_HOOKS
 #option		MINIROOTSIZE=20480		# disktab.10mb
 #option		MINIROOTSIZE=30720		# disktab.12mb
 option		MINIROOTSIZE=98304		# disktab.48mb
+#option   MINIROOTSIZE=131072   # disktab.64mb
 option		NKPTP=16 			# Needed when kernel+ramdisk > 16Mb
 config		bsd		root on rd0a swap on rd0b and wd0b and wd1b
 pseudo-device	rd	1

--- a/GENERIC-RD
+++ b/GENERIC-RD
@@ -32,6 +32,7 @@ option		PROCFS		# /proc
 
 option          RAMDISK_HOOKS
 option          MINIROOTSIZE=98304	# disktab.48mb
+#option          MINIROOTSIZE=131072            # disktab.64mb
 option          NKPTP=16		# Needed when kernel+ramdisk > 16Mb
 config		bsd	root on rd0a swap on rd0b and wd0b and wd1b
 pseudo-device	rd	1

--- a/NTFS
+++ b/NTFS
@@ -47,7 +47,8 @@ option          RAMDISK_HOOKS
 #option		MINIROOTSIZE=19456		# disktab.9.5mb
 #option		MINIROOTSIZE=20480		# disktab.10mb
 #option		MINIROOTSIZE=30720		# disktab.12mb
-option          MINIROOTSIZE=98304              # disktab.48mb
+option    MINIROOTSIZE=98304    # disktab.48mb
+#option   MINIROOTSIZE=131072   # disktab.64mb
 option          NKPTP=16 			# Needed when kernel+ramdisk > 16Mb
 
 config          bsd     root on rd0a swap on rd0b and wd0b and wd1b

--- a/PCENGINES
+++ b/PCENGINES
@@ -155,7 +155,8 @@ option          RAMDISK_HOOKS
 #option		MINIROOTSIZE=19456		# disktab.9.5mb
 #option		MINIROOTSIZE=20480		# disktab.10mb
 #option		MINIROOTSIZE=30720		# disktab.15mb
-option          MINIROOTSIZE=98304              # disktab.48mb
+option    MINIROOTSIZE=98304    # disktab.48mb
+#option   MINIROOTSIZE=131072   # disktab.64mb
 option          NKPTP=16 			# Needed when kernel+ramdisk > 16Mb
 
 config          bsd     root on rd0a swap on rd0b and wd0b and wd1b

--- a/SOEKRIS4501
+++ b/SOEKRIS4501
@@ -86,6 +86,7 @@ option		RAMDISK_HOOKS
 #option		MINIROOTSIZE=20480		# disktab.10mb
 #option		MINIROOTSIZE=30720		# disktab.12mb
 option		MINIROOTSIZE=98304		# disktab.48mb
+#option   MINIROOTSIZE=131072   # disktab.64mb
 option		NKPTP=16 				# Needed when kernel+ramdisk > 16Mb
 
 config          bsd     root on rd0a swap on rd0b and wd0b and wd1b

--- a/SOEKRIS4521
+++ b/SOEKRIS4521
@@ -86,6 +86,7 @@ option          RAMDISK_HOOKS
 #option		MINIROOTSIZE=20480		# disktab.10mb
 #option		MINIROOTSIZE=30720		# disktab.12mb
 option		MINIROOTSIZE=98304		# disktab.48mb
+#option   MINIROOTSIZE=131072   # disktab.64mb
 option		NKPTP=16 				# Needed when kernel+ramdisk > 16Mb
 
 config		bsd		root on rd0a swap on rd0b and wd0b and wd1b

--- a/SOEKRIS4801
+++ b/SOEKRIS4801
@@ -125,6 +125,7 @@ option		RAMDISK_HOOKS
 #option		MINIROOTSIZE=20480		# disktab.10mb
 #option		MINIROOTSIZE=30720		# disktab.12mb
 option		MINIROOTSIZE=98304		# disktab.48mb
+#option   MINIROOTSIZE=131072   # disktab.64mb
 option		NKPTP=16 # Needed when kernel+ramdisk > 16Mb
 config		bsd		root on rd0a swap on rd0b and wd0b and wd1b
 pseudo-device	rd	1

--- a/SOEKRIS5501
+++ b/SOEKRIS5501
@@ -84,7 +84,8 @@ option		RAMDISK_HOOKS
 #option		MINIROOTSIZE=16384		# disktab.8mb
 #option		MINIROOTSIZE=19456		# disktab.9.5mb
 #option		MINIROOTSIZE=20480		# disktab.10mb
-option		MINIROOTSIZE=98304              # disktab.48mb
+option		MINIROOTSIZE=98304    # disktab.48mb
+#option   MINIROOTSIZE=131072   # disktab.64mb
 option		NKPTP=16 			# Needed when kernel+ramdisk > 16Mb
 config		bsd		root on rd0a swap on rd0b and wd0b and wd1b
 pseudo-device	rd	1

--- a/WRAP12
+++ b/WRAP12
@@ -87,6 +87,7 @@ option          RAMDISK_HOOKS
 #option		MINIROOTSIZE=20480		# disktab.10mb
 #option		MINIROOTSIZE=30720		# disktab.12mb
 option          MINIROOTSIZE=98304              # disktab.48mb
+#option          MINIROOTSIZE=131072            # disktab.64mb
 option          NKPTP=16 			# Needed when kernel+ramdisk > 16Mb
 
 config          bsd     root on rd0a swap on rd0b and wd0b and wd1b

--- a/disktabs/disktab.64mb
+++ b/disktabs/disktab.64mb
@@ -1,0 +1,23 @@
+# /dev/rvnd0c:
+type: unknown
+disk: rdroot8
+label: 
+flags:
+bytes/sector: 512
+sectors/track: 128
+tracks/cylinder: 1
+sectors/cylinder: 128
+cylinders: 1024
+total sectors: 131072
+rpm: 3600
+interleave: 1
+trackskew: 0
+cylinderskew: 0
+headswitch: 0		# microseconds
+track-to-track seek: 0	# microseconds
+drivedata: 0 
+
+2 partitions:
+#        size   offset    fstype   [fsize bsize   cpg]
+  a:   131072        0    4.2BSD     1024  4096    20 	# (Cyl.    0 - 1023)
+  c:   131072        0    unused        0     0       	# (Cyl.    0 - 1023)


### PR DESCRIPTION
to include something like bacula-fd which require heavy libs
defaults still 48mb
