### PR TITLE
Actually use mk-mini.conf. While at it, disable SKEY in the build.

### DIFF
--- a/build-release-injail.sh
+++ b/build-release-injail.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export BUILDCONF=/mk-mini.conf
+export MAKECONF=/mk-mini.conf
 
 cd /usr/src
 

--- a/mk-mini.conf
+++ b/mk-mini.conf
@@ -3,6 +3,7 @@ PIPE=-pipe
 STATIC=
 DEBUG=
 
+SKEY=no
 KERBEROS=no
 KERBEROS5=no
 YP=no


### PR DESCRIPTION
Brings down miniroot usage considerably (before/after):

```
512-Blocks  Used    Avail
95102   93224    1878
95102   75464   19638
```

That’s with the heavy iked and other stuff from #26 included.
